### PR TITLE
Add PRD and planning docs

### DIFF
--- a/Diagram.md
+++ b/Diagram.md
@@ -1,0 +1,28 @@
+# Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph Interfaces
+        A[CLI] 
+        B[Web UI]
+    end
+    subgraph Core
+        C[Assistant]
+        D[Tool Loader]
+    end
+    subgraph Tools
+        E[Built-in Tools]
+        F[Generated Tools]
+    end
+    subgraph External
+        G[Anthropic API]
+        H[E2B Sandbox]
+    end
+    A --> C
+    B --> C
+    C --> D
+    D --> E
+    D --> F
+    C --> G
+    F --> H
+```

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,32 @@
+# Product Requirements Document (PRD)
+
+## Overview
+`neurox-agent` (Claude Engineer v3) is a Python based assistant that combines a CLI and web interface to interact with Anthropic's Claude model. It dynamically loads tools for file management, web scraping and code execution, and can even create new tools autonomously. The goal is to provide a self‑improving framework that developers can use to automate tasks and extend capabilities during conversation.
+
+## Goals
+- Offer both CLI and web UI for interacting with Claude
+- Support dynamic tool loading and creation
+- Track token usage and conversation history
+- Provide rich debugging output and progress indicators
+- Remain easy to extend and deploy
+
+## Milestones
+### Short‑Term (within 1 week)
+1. **Documentation completeness** – add architecture diagram and PRD (this document)
+2. **Task tracking** – maintain TODO lists for upcoming work
+3. **Basic CI** – ensure linting and tests run locally (ruff + pytest)
+
+### Mid‑Term (within 1 month)
+1. **Improve test coverage** across existing tools and assistant logic
+2. **Package distribution** via PyPI including project metadata
+3. **Docker support** for easy deployment of the web UI
+
+### Long‑Term (within 3 months)
+1. **Plugin ecosystem** allowing external developers to register new tools
+2. **Advanced conversation analytics** with persistent storage
+3. **Continuous integration** with automated deployment pipelines
+
+## References
+- `readme.md` – installation, usage and tool descriptions
+- `tools/` – collection of builtin tools
+- `templates/` & `static/` – web interface assets

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+## Short-Term
+- **T1**: Finalize `PRD.md` and `Diagram.md` and keep them updated.
+- **T2**: Add basic CI script to run `ruff` and `pytest` on each push.
+- **T3**: Create initial unit tests covering the assistant and at least one tool.
+- **T4**: Write CONTRIBUTING guidelines for new contributors.

--- a/TODO.next.md
+++ b/TODO.next.md
@@ -1,0 +1,11 @@
+# Next TODOs
+
+## Mid-Term
+- **M1**: Expand test coverage for all built-in tools.
+- **M2**: Package project for PyPI distribution.
+- **M3**: Provide Docker configuration for the web UI.
+
+## Long-Term
+- **L1**: Implement plugin system for third-party tools.
+- **L2**: Add analytics and persistent conversation storage.
+- **L3**: Integrate CI/CD pipeline for automated deployment.

--- a/plans/prd_docs_update.md
+++ b/plans/prd_docs_update.md
@@ -1,0 +1,16 @@
+# Plan: Add project documentation
+
+## Goal
+Create missing project documentation files and diagrams based on the current repository. Implement PRD with milestones and create TODO lists. Update README and add architecture diagram. No code changes to application logic.
+
+## Steps
+1. Create `PRD.md` describing project vision, features and milestones (short-, mid-, long-term).
+2. Create `Diagram.md` with a mermaid diagram representing high level architecture (web UI, CLI, tools, core assistant, external APIs).
+3. Update `readme.md` with a brief note linking to PRD and diagram.
+4. Generate `TODO.md` with short term tasks derived from PRD. Generate `TODO.next.md` for mid/long tasks.
+5. Ensure plan and docs follow repository instructions in `AGENTS.md`.
+6. Run `ruff .` and `pytest -q` to verify no lint or test regressions.
+
+## Impact
+- Adds documentation only; no changes to runtime code.
+- Should not affect tests.

--- a/readme.md
+++ b/readme.md
@@ -255,3 +255,6 @@ E2B_API_KEY=your_e2b_key
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Doriandarko/claude-engineer&type=Date)](https://star-history.com/#Doriandarko/claude-engineer&Date)
+
+## Project Documents
+See [PRD.md](PRD.md) for planned milestones and [Diagram.md](Diagram.md) for an overview of the architecture.


### PR DESCRIPTION
## Summary
- document project milestones in PRD
- outline architecture in Diagram.md
- add short and long term task lists
- reference new docs from README
- record plan for changes

## Testing
- `ruff check .` *(fails: 659 errors in repo)*
- `pytest --override-ini="addopts=" -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683c13099c1c8327a8d03b303aeeaa3e