### PR TITLE
Implement T3: add initial tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,5 +3,5 @@
 ## Short-Term
 - ~~**T1**: Finalize `PRD.md` and `Diagram.md` and keep them updated.~~
 - ~~**T2**: Add basic CI script to run `ruff` and `pytest` on each push.~~
-- **T3**: Create initial unit tests covering the assistant and at least one tool.
+- ~~**T3**: Create initial unit tests covering the assistant and at least one tool.~~
 - **T4**: Write CONTRIBUTING guidelines for new contributors.

--- a/plans/t3_initial_unit_tests.md
+++ b/plans/t3_initial_unit_tests.md
@@ -1,0 +1,19 @@
+# Plan T3: Initial unit tests
+
+## Goal
+Create basic unit tests covering the Assistant reset functionality and one built-in tool (FileCreatorTool).
+
+## Steps
+1. Create `tests/test_assistant_reset.py`:
+   - Mock `anthropic` client to avoid dependency.
+   - Patch `Config.ANTHROPIC_API_KEY` and `Assistant._load_tools`.
+   - Verify `reset()` clears conversation history and token count.
+2. Create `tests/test_file_creator_tool.py`:
+   - Use pytest `tmp_path` fixture to create a temporary file.
+   - Call `FileCreatorTool.execute` with a single file specification.
+   - Assert file contents and JSON result show success.
+3. Run `ruff .` and `pytest -q` to ensure tests and lint pass.
+4. Update `TODO.md` to mark **T3** as completed.
+
+## Impact
+Adds first unit tests to the project, improving reliability and enabling future CI checks.

--- a/tests/test_assistant_reset.py
+++ b/tests/test_assistant_reset.py
@@ -1,0 +1,64 @@
+import sys
+import types
+from pathlib import Path
+
+sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda: None)
+rich_stub = types.SimpleNamespace(
+    console=types.SimpleNamespace(
+        Console=type(
+            "DummyConsole",
+            (),
+            {
+                "print": lambda self, *a, **k: None,
+            },
+        )
+    ),
+    markdown=types.SimpleNamespace(Markdown=lambda text: text),
+    live=types.SimpleNamespace(Live=object),
+    spinner=types.SimpleNamespace(Spinner=object),
+    panel=types.SimpleNamespace(Panel=object),
+)
+sys.modules['rich'] = rich_stub
+sys.modules['rich.console'] = rich_stub.console
+sys.modules['rich.markdown'] = rich_stub.markdown
+sys.modules['rich.live'] = rich_stub.live
+sys.modules['rich.spinner'] = rich_stub.spinner
+sys.modules['rich.panel'] = rich_stub.panel
+prompt_toolkit_stub = types.SimpleNamespace(
+    prompt=lambda *a, **k: "",
+    styles=types.SimpleNamespace(Style=object),
+)
+sys.modules['prompt_toolkit'] = prompt_toolkit_stub
+sys.modules['prompt_toolkit.styles'] = prompt_toolkit_stub.styles
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from config import Config  # noqa: E402
+
+
+# Provide a minimal stub for the anthropic client
+class DummyMessages:
+    def create(self, *args, **kwargs):
+        return types.SimpleNamespace(stop_reason="stop", content=[])
+
+class DummyClient:
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.messages = DummyMessages()
+
+def test_reset_clears_history_and_tokens(monkeypatch):
+    sys.modules['anthropic'] = types.SimpleNamespace(Anthropic=DummyClient)
+
+    from ce3 import Assistant  # import after stubbing anthropic
+
+    monkeypatch.setattr(Config, "ANTHROPIC_API_KEY", "test")
+    monkeypatch.setattr(Assistant, "_load_tools", lambda self: [])
+
+    assistant = Assistant()
+    assistant.conversation_history = [{"role": "user", "content": "hi"}]
+    assistant.total_tokens_used = 10
+
+    assistant.reset()
+
+    assert assistant.conversation_history == []
+    assert assistant.total_tokens_used == 0

--- a/tests/test_file_creator_tool.py
+++ b/tests/test_file_creator_tool.py
@@ -1,0 +1,22 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.filecreatortool import FileCreatorTool
+
+
+def test_file_creator_creates_file(tmp_path):
+    tool = FileCreatorTool()
+    file_path = tmp_path / "hello.txt"
+    result_json = tool.execute(files={"path": str(file_path), "content": "hello"})
+
+    assert file_path.exists()
+    assert file_path.read_text(encoding="utf-8") == "hello"
+
+    result = json.loads(result_json)
+    assert result["created_files"] == 1
+    assert result["failed_files"] == 0
+    assert result["results"][0]["success"] is True
+    assert Path(result["results"][0]["path"]) == file_path


### PR DESCRIPTION
## Summary
- plan T3 to add initial unit tests
- test assistant reset without external deps
- test FileCreatorTool creates files
- mark T3 done in TODO

## Testing
- `ruff check .`
- `pytest -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_683c2596785c83278d361052b7746364